### PR TITLE
Fix links to babylon spec

### DIFF
--- a/translations/af/plugin-handbook.md
+++ b/translations/af/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/ar/plugin-handbook.md
+++ b/translations/ar/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/ca/plugin-handbook.md
+++ b/translations/ca/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/cs/plugin-handbook.md
+++ b/translations/cs/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel je kompilátor JavaScriptu, který kompiluje ze zdrojového kódu na zdroj
 
 Každý z těchto kroků obsahuje vytváření a práci s [Abstraktním syntaktickým stromem](https://en.wikipedia.org/wiki/Abstract_syntax_tree) nebo-li AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/da/plugin-handbook.md
+++ b/translations/da/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/de/plugin-handbook.md
+++ b/translations/de/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel ist ein JavaScript Compiler, genauer ein Source zu Source Compiler, auch "
 
 In jeden dieser Schritte ist das Erstellen oder das Arbeiten mit einem [Abstrakten Syntaxbaum](https://en.wikipedia.org/wiki/Abstract_syntax_tree) oder AST enthalten.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/el/plugin-handbook.md
+++ b/translations/el/plugin-handbook.md
@@ -90,7 +90,7 @@
 
 Κάθενα από τα βήματα συμπεριλαμβάνουν την δημιουργία ή χρήση μιας [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) εν συντομία AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -104,7 +104,7 @@ Each of these steps involve creating or working with an
 [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or
 AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1968,7 +1968,7 @@ generated from the node definitions.
 You can find all of the actual
 [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions)
 and you can see them
-[documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+[documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 ----
 

--- a/translations/es-ES/plugin-handbook.md
+++ b/translations/es-ES/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel es un compilador de JavaScript, específicamente un compilador de fuente a
 
 Cada uno de estos pasos implican crear o trabajar con un [Árbol de Sintaxis Abstracta](https://en.wikipedia.org/wiki/Abstract_syntax_tree) ó AST por sus siglas en inglés.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/fa-IR/plugin-handbook.md
+++ b/translations/fa-IR/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/fi/plugin-handbook.md
+++ b/translations/fi/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel on JavaScript-kääntäjä, tarkemmin ottaen lähdekoodista-lähdekoodiin 
 
 Jokaisessa allaolevassa esimerkissä sinun tulee joko luoda tai käsitellä [Abstrakteja syntaksipuita](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (ts. AST:ia).
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/fr/plugin-handbook.md
+++ b/translations/fr/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel est un compilateur JavaScript, plus précisément un compilateur de code s
 
 Chacune de ces étapes implique la création ou le travail avec une [Arbre de syntaxe abstraite](https://en.wikipedia.org/wiki/Abstract_syntax_tree) ou AST.
 
-> Babel utilise un AST modifié de [ESTree](https://github.com/estree/estree), avec la spécification principale située [ici](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel utilise un AST modifié de [ESTree](https://github.com/estree/estree), avec la spécification principale située [ici](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 Il est très improbable que vous appreniez par cœur les signatures de méthode du constructeur pour chaque type de nœud. Donc vous devriez prendre du temps et comprendre comment ils sont générés depuis les définitions du nœud.
 
-Vous pouvez trouver toutes les [définitions actuelles ici](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) et vous pouvez les voir [documentées ici](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+Vous pouvez trouver toutes les [définitions actuelles ici](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) et vous pouvez les voir [documentées ici](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/he/plugin-handbook.md
+++ b/translations/he/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/hu/plugin-handbook.md
+++ b/translations/hu/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/id-ID/plugin-handbook.md
+++ b/translations/id-ID/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel adalah compiler JavaScript, yang lebih spesifik sebuah kompiler sumber ke 
 
 Setiap langkah meliputi pembuatan atau pengerjaan [Pohon Sintak Abstrak](https://en.wikipedia.org/wiki/Abstract_syntax_tree) atau AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/it/plugin-handbook.md
+++ b/translations/it/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel è un compilatore JavaScript, specificamente un compilatore di fonte a fon
 
 Ognuno di questi passaggi comportano la creazione o l'utilizzo con un [Albero Sintattico Astratto](https://en.wikipedia.org/wiki/Abstract_syntax_tree) o AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/ja/plugin-handbook.md
+++ b/translations/ja/plugin-handbook.md
@@ -90,7 +90,7 @@ BabelはJavaScriptのコンパイラ、特にソースからソースへ変換�
 
 コードの変換の各ステップでは[抽象構文木(ASTs)](https://en.wikipedia.org/wiki/Abstract_syntax_tree)またはASTを利用します。
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/ko/plugin-handbook.md
+++ b/translations/ko/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel은 JavaScript 컴파일러입니다. 정확히는 source-to-source 컴파�
 
 각 과정들은 [추상 구문 트리(AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree)를 생성하거나 이것을 다루게됩니다.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/nl/plugin-handbook.md
+++ b/translations/nl/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Elk van deze stappen heeft te maken met[Abstracte Syntaxis-bomen](https://en.wikipedia.org/wiki/Abstract_syntax_tree), in het Engels afgekort als AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/no/plugin-handbook.md
+++ b/translations/no/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel er en JavaScript kompilerer, og er en blokk-til-kilde kompilerer, og er of
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/pl/plugin-handbook.md
+++ b/translations/pl/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/pt-BR/plugin-handbook.md
+++ b/translations/pt-BR/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel é um compilador JavaScript, especificamente um compilador de código para
 
 Cada um destes passos envolvem criação ou trabalho com uma [Árvore de Sintaxe Abstrata](https://en.wikipedia.org/wiki/Abstract_syntax_tree) ou AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1817,7 +1817,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/pt-PT/plugin-handbook.md
+++ b/translations/pt-PT/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/ro/plugin-handbook.md
+++ b/translations/ro/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel este un compilator de JavaScript, mai exact un compilator sursă-la-sursă
 
 Fiecare dintre acești pași implică crearea sau lucrul cu un [Arbore Abstract de Sintaxă](https://en.wikipedia.org/wiki/Abstract_syntax_tree) sau AST.
 
-> Babel folosește un AST modificat din [ESTree](https://github.com/estree/estree), cu specificațiile interne aflate [aici](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel folosește un AST modificat din [ESTree](https://github.com/estree/estree), cu specificațiile interne aflate [aici](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 Este foarte puţin probabil că veți memora vreodată semnăturile metodei constructor pentru fiecare tip de nod. Așadar, ar trebui să vă rezervați ceva timp să înţelegeți cum sunt generate acestea din definiţiile nodului.
 
-Puteţi găsi toate [definiţiile aici](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) şi le puteţi vedea [documentate aici](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+Puteţi găsi toate [definiţiile aici](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) şi le puteţi vedea [documentate aici](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/ru/plugin-handbook.md
+++ b/translations/ru/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel - это JavaScript компилятор, точнее компилято�
 
 Каждый из этих шагов требует создания или работы с [Абстрактным синтаксическим деревом](https://en.wikipedia.org/wiki/Abstract_syntax_tree), или AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/sk-SK/plugin-handbook.md
+++ b/translations/sk-SK/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/sr/plugin-handbook.md
+++ b/translations/sr/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel je JavaScript kompajler, tačnije kompajler iz koda u kod, što se najče�
 
 Svaki od koraka pri kompajliranju uključuje kreiranje ili korišćenje apstraktnog sintaksnog stabla [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) tj. AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/sv-SE/plugin-handbook.md
+++ b/translations/sv-SE/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel är en JavaScript kompilator, särskilt en källa-till-källa kompilator, 
 
 Alla dessa steg innebär att skapa eller arbeta med ett [Abstrakt Syntax träd](https://en.wikipedia.org/wiki/Abstract_syntax_tree) eller AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/tr/plugin-handbook.md
+++ b/translations/tr/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/uk/plugin-handbook.md
+++ b/translations/uk/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel is a JavaScript compiler, specifically a source-to-source compiler, often 
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/vi/plugin-handbook.md
+++ b/translations/vi/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel là 1 trình biên dịch (compiler) dành cho Javascript, đặt biệt l
 
 Each of these steps involve creating or working with an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) or AST.
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/zh-Hans/plugin-handbook.md
+++ b/translations/zh-Hans/plugin-handbook.md
@@ -1819,7 +1819,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 

--- a/translations/zh-Hant/plugin-handbook.md
+++ b/translations/zh-Hant/plugin-handbook.md
@@ -90,7 +90,7 @@ Babel 是一個 JavaScript compiler，因為是 source-to-source 而非 source-t
 
 每一個步驟包含 [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) 或 AST 的建造或是使用
 
-> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babylon/blob/master/ast/spec.md).
+> Babel uses an AST modified from [ESTree](https://github.com/estree/estree), with the core spec located [here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md).
 
 ```js
 function square(n) {
@@ -1818,7 +1818,7 @@ member.expression.property
 
 It's very unlikely that you will ever memorize the builder method signatures for every node type. So you should take some time and understand how they are generated from the node definitions.
 
-You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/doc/ast/spec.md)
+You can find all of the actual [definitions here](https://github.com/babel/babel/tree/master/packages/babel-types/src/definitions) and you can see them [documented here](https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md)
 
 * * *
 


### PR DESCRIPTION
Babylon's spec is now in babel's mono repo.
This PR is to fix it.

https://github.com/babel/babel/blob/master/packages/babylon/ast/spec.md