### PR TITLE
doc: fix Markdown usage and use better translation in User Handbook(zh-Hans & zh-Hant)

### DIFF
--- a/translations/zh-Hans/user-handbook.md
+++ b/translations/zh-Hans/user-handbook.md
@@ -209,13 +209,12 @@ require("./index.js");
 $ node register.js
 ```
 
-> **注意：**你不能在你要编译的文件内同时注册 Babel，因为 node 会在 Babel 编译它之前就将它执行了。
-> 
+> **注意：** 你不能在要编译的文件中注册Babel，因为 node 会在 Babel 编译它之前就将它执行了。 
 > ```js
-require("babel-register");
-// 未编译的：
-console.log("Hello world!");
-```
+> require("babel-register");
+> // 未编译的：
+> console.log("Hello world!");
+> ```
 
 ## <a id="toc-babel-node"></a>`babel-node`
 

--- a/translations/zh-Hant/user-handbook.md
+++ b/translations/zh-Hant/user-handbook.md
@@ -209,13 +209,12 @@ require("./index.js");
 $ node register.js
 ```
 
-> **注意：**您不能在想編譯的檔案中注冊 Babel。因為 node 會在 Babel 編譯它前就先執行它。
-> 
+> **注意：** 您不能在想編譯的檔案中注冊 Babel。因為 node 會在 Babel 編譯它前就先執行它。 
 > ```js
-require("babel-register");
-// not compiled:
-console.log("Hello world!");
-```
+> require("babel-register");
+> // not compiled:
+> console.log("Hello world!");
+> ```
 
 ## <a id="toc-babel-node"></a>`babel-node`
 


### PR DESCRIPTION
## Change log:

### zh-Hans

![image](https://user-images.githubusercontent.com/24861316/50777969-d9a13480-12d7-11e9-9b82-4e928c30c819.png)

And the translation change：

> `The original:` You can't register Babel in the same file that you want to compile.

Original translation: ~~你不能在你要编译的文件内同时注册 Babel~~  

Better translation :  你不能在要编译的文件中注册Babel

### zh-Hant

![image](https://user-images.githubusercontent.com/24861316/50778009-efaef500-12d7-11e9-8075-46e003a6c87e.png)

